### PR TITLE
Remove support for POSIXLY_CORRECT

### DIFF
--- a/getopt.go
+++ b/getopt.go
@@ -1,6 +1,6 @@
 // Package getopt provides GNU-style argument parsing for both short and long arguments.
 //
-// Differences from Posix getopt:
+// Differences from Posix and GNU getopt:
 //  1. There are no global variables. All operations are performed on a Getopt struct that maintains state between
 //     successive calls. To read an option's argument value, read [Opt.Arg] instead of optarg. To reset option-parsing,
 //     create a new [Getopt] struct instead of assign optreset.
@@ -16,6 +16,8 @@
 //  5. The Flag and Val fields of Option have type rune, not int.
 //  6. The list of options and arguments cannot be changed in the middle of parsing. The argument list and option
 //     definition are set once at the start, and then you just call Getopt or GetoptLong with no parameters.
+//  7. The POSIXLY_CORRECT environment variable is ignored. The library runs as though the environment variable is never
+//     set. Use leading '+' or '-' characters in the option specification instead; see [Ordering] for more.
 package getopt
 
 import (
@@ -66,19 +68,18 @@ const (
 	// RequireOrder means options that follow non-option arguments are not recognized as options. Getopt will stop
 	// processing the argument list when the first non-option is seen. This mode can be useful when implementing a tool
 	// that has subcommands, where the main command and the subcommands have their separate sets of options. This
-	// behavior is what POSIX specifies should happen. To use this mode even when POSIXLY_CORRECT is not set, start the
-	// short option specification with a '+'.
+	// behavior is what POSIX specifies should happen, although it is not the default in this package. To use this mode,
+	// start the short option specification with a '+'.
 	RequireOrder Ordering = iota
 
 	// Permute means Getopt will permute the contents of Args as it scans, so that eventually all the non-options are at
-	// the end. This allows options to be given in any order and is the default behavior, unless the POSIXLY_CORRECT
-	// environment variable is set at the time the [Getopt] struct is initialized.
+	// the end. This allows options to be given in any order and is the default behavior.
 	Permute
 
-	// ReturnInOrder is an option available to programs that were written to expect options and other arguments in any
-	// order and that care about the ordering of the two. In this mode, non-option arguments are returned by [Getopt] as
-	// though they belong to an option with a character code of 1. To request this ordering behavior, start the short
-	// option specification with a '-'.
+	// ReturnInOrder is an option available to programs that expect options and other arguments in any order and that
+	// care about the ordering of the two. In this mode, non-option arguments are returned as though they belong to an
+	// option with a character code of 1. To request this ordering behavior, start the short option specification with a
+	// '-'.
 	ReturnInOrder
 )
 
@@ -175,8 +176,8 @@ func (g *Getopt) GetoptLongOnly() (*Opt, error) {
 // options.
 //
 // If opts begins with '-', then non-option arguments are treated as arguments to the option 1. This behavior mimics the
-// GNU extension. If opts begins with '+', or if POSIXLY_CORRECT is set in the environment at the time New is called,
-// then arguments will not be permuted during parsing.
+// GNU extension. If opts begins with '+', then arguments will not be permuted during parsing; parsing will stop when a
+// non-option argument is encountered.
 //
 // The argument list is assumed to include the program name at index 0; it is not returned or processed as a real
 // argument.

--- a/internal_test.go
+++ b/internal_test.go
@@ -17,6 +17,9 @@ func optFields(ordering, w, opts types.GomegaMatcher) Fields {
 	}
 }
 
+// This isn't supported, but we still want to have tests to _demonstrate_ that it's not used.
+const PosixlyCorrect = "POSIXLY_CORRECT"
+
 var _ = Describe("Option parsing", func() {
 	Context("with nearly empty options", func() {
 		DescribeTableSubtree("with no environment variabe set",
@@ -38,7 +41,7 @@ var _ = Describe("Option parsing", func() {
 			Entry(nil, "+", RequireOrder),
 		)
 
-		DescribeTableSubtree("in posixly correct mode",
+		DescribeTableSubtree("ignores posixly correct mode",
 			func(opts string, expected Ordering) {
 				BeforeEach(func() {
 					Expect(os.Setenv(PosixlyCorrect, "yes")).To(Succeed())
@@ -52,8 +55,8 @@ var _ = Describe("Option parsing", func() {
 					)))
 				})
 			},
-			Entry(nil, "", RequireOrder),
-			Entry(nil, "-", ReturnInOrder), // This override environment variable.
+			Entry(nil, "", Permute),
+			Entry(nil, "-", ReturnInOrder),
 			Entry(nil, "+", RequireOrder),
 		)
 

--- a/iter_test.go
+++ b/iter_test.go
@@ -3,7 +3,6 @@ package getopt_test
 import (
 	"fmt"
 	"iter"
-	"os"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -64,7 +63,6 @@ var _ = Describe("Getopt iterator interface", func() {
 	})
 
 	It("returns remaining arguments", func() {
-		Expect(os.Unsetenv(getopt.PosixlyCorrect)).To(Succeed())
 		var remaining []string
 		opts := collect(getopt.Iterate([]string{"prg", "-a", "arg1", "-b", "arg2"}, "ab", &remaining))
 		Expect(opts).To(HaveLen(2))
@@ -73,8 +71,6 @@ var _ = Describe("Getopt iterator interface", func() {
 })
 
 func ExampleIterate() {
-	_ = os.Unsetenv(getopt.PosixlyCorrect)
-
 	args := []string{"prg", "-a", "arg1", "-b", "arg2"}
 	optionDefinition := "ab"
 

--- a/shortopts.go
+++ b/shortopts.go
@@ -1,7 +1,6 @@
 package getopt
 
 import (
-	"os"
 	"strings"
 )
 
@@ -18,22 +17,18 @@ func (inf *optinfo) HasOpt(c rune) bool {
 	return ok
 }
 
-// PosixlyCorrect holds the name of the environment variable that can affect how options are interpretted. When it's
-// set, the application will not permute the argument list.
-const PosixlyCorrect = "POSIXLY_CORRECT"
-
 func parseShortOptionSpec(options string) optinfo {
 	const (
 		inorderPrefix = "-"
 		posixPrefix   = "+"
 	)
 	var result optinfo
-	_, ok := os.LookupEnv("POSIXLY_CORRECT")
-	if strings.HasPrefix(options, inorderPrefix) {
+	switch {
+	case strings.HasPrefix(options, inorderPrefix):
 		result.Ordering = ReturnInOrder
-	} else if ok || strings.HasPrefix(options, posixPrefix) {
+	case strings.HasPrefix(options, posixPrefix):
 		result.Ordering = RequireOrder
-	} else {
+	default:
 		result.Ordering = Permute
 	}
 	if strings.HasPrefix(options, posixPrefix) || strings.HasPrefix(options, inorderPrefix) {


### PR DESCRIPTION
It's a backward-compatibility option for programs that were written against a POSIX version of `getopt` and now are using a GNU version with additional features. It doesn't really have any meaning in the context of this new, non-C library.

Fixes #3.