### PR TITLE
Improve iteration examples

### DIFF
--- a/getopt.go
+++ b/getopt.go
@@ -109,8 +109,9 @@ type Getopt struct {
 //
 // If C is 1, then ordering is [ReturnInOrder] and Arg points to the current non-option argument.
 //
-// Otherwise, C holds the rune value of the matched short option or Val of the matched long option (in which case
-// LongInd also holds the index of the matched long option).
+// Otherwise, C holds the rune value of the matched short option or Val of the matched long option. When a short option
+// is matched, LongInd will be -1. When a long option is matched, LongInd holds the zero-based index of the matched
+// option from the longopts argument to [NewLong].
 type Opt struct {
 	C       rune
 	Arg     *string
@@ -147,8 +148,7 @@ func (g *Getopt) Optind() int {
 // unique or is an exact match for some defined option. If they have an argument, it follows the option name in the same
 // Args element, separated from the option name by a '=', or else in next Args element. When Getopt finds a long-named
 // option, it returns an Opt whose C field is 0 if that option's 'Flag' field is non-nil, or the value of the option's
-// 'Val' field if the 'Flag' field is nil. The Opt.LongInd field is only valid when a long-named option has
-// been found.
+// 'Val' field if the 'Flag' field is nil.
 func (g *Getopt) Getopt() (*Opt, error) {
 	return g.getoptInternal(false)
 }
@@ -349,6 +349,7 @@ func (g *Getopt) processLongOption(longOnly bool, prefix string) (*Opt, error) {
 	if pfound.Flag != nil {
 		*pfound.Flag = pfound.Val
 		return &Opt{
+			C:       0,
 			LongInd: optionIndex,
 			Arg:     arg,
 		}, nil
@@ -433,8 +434,9 @@ func (g *Getopt) getoptInternal(longOnly bool) (*Opt, error) {
 			arg := &g.Args[g.optind]
 			g.optind++
 			return &Opt{
-				C:   1,
-				Arg: arg,
+				C:       1,
+				LongInd: -1,
+				Arg:     arg,
 			}, nil
 		}
 
@@ -529,7 +531,8 @@ func (g *Getopt) getoptInternal(longOnly bool) (*Opt, error) {
 		g.nextChar = nil
 	}
 	return &Opt{
-		C:   c,
-		Arg: arg,
+		C:       c,
+		LongInd: -1,
+		Arg:     arg,
 	}, nil
 }

--- a/getopt_test.go
+++ b/getopt_test.go
@@ -134,7 +134,7 @@ var _ = Describe("Getopt", func() {
 	It("continues after detecting error", func() {
 		longOpts := []Option{
 			{Name: "aaa", Val: 'a'},
-			{Name: "bbb", Val: 'd'},
+			{Name: "bbb", Val: 'b'},
 			{Name: "ccc", Val: 'c'},
 		}
 		g := NewLong([]string{"prg", "-acb"}, "", longOpts)

--- a/iter.go
+++ b/iter.go
@@ -5,7 +5,7 @@ import (
 )
 
 // Iterate returns an iterator for options parsed from the given argument list. When iteration terminates, the slice
-// pointer will hold the remaining unparsed arguments.
+// pointer, if non-nil, will hold the remaining unparsed arguments.
 func Iterate(args []string, opts string, remaining *[]string) iter.Seq2[*Opt, error] {
 	g := New(args, opts)
 	return func(yield func(*Opt, error) bool) {
@@ -14,12 +14,14 @@ func Iterate(args []string, opts string, remaining *[]string) iter.Seq2[*Opt, er
 				break
 			}
 		}
-		*remaining = g.Args[g.Optind():]
+		if remaining != nil {
+			*remaining = g.Args[g.Optind():]
+		}
 	}
 }
 
 // IterateLong returns an iterator for options parsed from the given argument list and option definitions. When
-// iteration terminates, the slice pointer will hold the remaining unparsed arguments.
+// iteration terminates, the slice pointer, if non-nil, will hold the remaining unparsed arguments.
 func IterateLong(args []string, opts string, longOptions []Option, remaining *[]string) iter.Seq2[*Opt, error] {
 	g := NewLong(args, opts, longOptions)
 	return func(yield func(*Opt, error) bool) {
@@ -28,12 +30,14 @@ func IterateLong(args []string, opts string, longOptions []Option, remaining *[]
 				break
 			}
 		}
-		*remaining = g.Args[g.Optind():]
+		if remaining != nil {
+			*remaining = g.Args[g.Optind():]
+		}
 	}
 }
 
 // IterateLongOnly returns an iterator for options parsed from the given argument list and option definitions. When
-// iteration terminates, the slice pointer will hold the remaining unparsed arguments.
+// iteration terminates, the slice pointer, if non-nil, will hold the remaining unparsed arguments.
 func IterateLongOnly(args []string, opts string, longOptions []Option, remaining *[]string) iter.Seq2[*Opt, error] {
 	g := NewLong(args, opts, longOptions)
 	return func(yield func(*Opt, error) bool) {
@@ -42,6 +46,8 @@ func IterateLongOnly(args []string, opts string, longOptions []Option, remaining
 				break
 			}
 		}
-		*remaining = g.Args[g.Optind():]
+		if remaining != nil {
+			*remaining = g.Args[g.Optind():]
+		}
 	}
 }

--- a/iter_test.go
+++ b/iter_test.go
@@ -25,8 +25,7 @@ func collect[K comparable, V any](items iter.Seq2[K, V]) (result []Pair[K, V]) {
 
 var _ = Describe("Getopt iterator interface", func() {
 	It("returns in order", func() {
-		var remaining []string
-		opts := collect(getopt.Iterate([]string{"prg", "-ba", "-c"}, "abc", &remaining))
+		opts := collect(getopt.Iterate([]string{"prg", "-ba", "-c"}, "abc", nil))
 		Expect(opts).To(HaveExactElements(
 			MatchAllFields(Fields{
 				"K": PointTo(MatchFields(IgnoreExtras, Fields{"C": Equal('b')})),
@@ -44,8 +43,7 @@ var _ = Describe("Getopt iterator interface", func() {
 	})
 
 	It("continues on error", func() {
-		var remaining []string
-		opts := collect(getopt.Iterate([]string{"prg", "-acb"}, "", &remaining))
+		opts := collect(getopt.Iterate([]string{"prg", "-acb"}, "", nil))
 		Expect(opts).To(HaveExactElements(
 			MatchAllFields(Fields{
 				"K": BeNil(),
@@ -101,8 +99,7 @@ func ExampleIterateLong() {
 		{Name: "aaa", Val: 'a'},
 		{Name: "bbb", Val: 'b'},
 	}
-	var remaining []string
-	for opt, err := range getopt.IterateLong(args, optionDefinition, longOpts, &remaining) {
+	for opt, err := range getopt.IterateLong(args, optionDefinition, longOpts, nil) {
 		if err != nil {
 			_, _ = fmt.Println(err.Error())
 			continue

--- a/iter_test.go
+++ b/iter_test.go
@@ -93,3 +93,28 @@ func ExampleIterate() {
 	// got option b
 	// Remaining arguments: [arg1 arg2]
 }
+
+func ExampleIterateLong() {
+	args := []string{"prg", "-d", "--bbb", "-a"}
+	optionDefinition := "ab"
+	longOpts := []getopt.Option{
+		{Name: "aaa", Val: 'a'},
+		{Name: "bbb", Val: 'b'},
+	}
+	var remaining []string
+	for opt, err := range getopt.IterateLong(args, optionDefinition, longOpts, &remaining) {
+		if err != nil {
+			_, _ = fmt.Println(err.Error())
+			continue
+		}
+		if opt.LongInd == -1 {
+			_, _ = fmt.Printf("Got short option '%c'\n", opt.C)
+		} else {
+			_, _ = fmt.Printf("Got long option '%s'\n", longOpts[opt.LongInd].Name)
+		}
+	}
+	// Output:
+	// unrecognized option '-d'
+	// Got long option 'bbb'
+	// Got short option 'a'
+}


### PR DESCRIPTION
The single example for `Iterate` made published documentation look weird. This adds another example so they both appear as standalone examples. Writing the last example made it clear that it’s tedious to need to provide a slice pointer to receive remaining arguments even they aren’t needed